### PR TITLE
Replace `limit` with `pageSize` in query and scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - "node"
+  - "lts/*"
+  - "9"
+  - "8"
+  - "6"
+
+sudo: false
+
+before_script:
+  - npm run bootstrap

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.1.2",
-  "version": "0.1.1",
+  "lerna": "2.5.1",
+  "version": "independent",
   "hoist": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "lerna": "2.5.1",
-  "version": "independent",
+  "version": "0.1.1",
   "hoist": true
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "@types/jest": "^20.0.2",
     "@types/node": "^8.0.4",
     "jest": "^20.0.4",
-    "lerna": "^2.1.2",
-    "typescript": "^2.5.2"
+    "lerna": "^2.5.1",
+    "typescript": "^2.6"
   },
   "dependencies": {
     "aws-sdk": "^2.7.0"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^20.0.2",
+    "@types/jest": "^21",
     "@types/node": "^8.0.4",
-    "jest": "^20.0.4",
+    "jest": "^21",
     "lerna": "^2.5.1",
     "typescript": "^2.6"
   },

--- a/packages/dynamodb-auto-marshaller/package.json
+++ b/packages/dynamodb-auto-marshaller/package.json
@@ -15,9 +15,9 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^20.0.2",
+    "@types/jest": "^21",
     "@types/node": "^8.0.4",
-    "jest": "^20.0.4",
+    "jest": "^21",
     "typescript": "^2.6",
     "aws-sdk": "^2.7.0"
   },

--- a/packages/dynamodb-auto-marshaller/package.json
+++ b/packages/dynamodb-auto-marshaller/package.json
@@ -18,7 +18,7 @@
     "@types/jest": "^20.0.2",
     "@types/node": "^8.0.4",
     "jest": "^20.0.4",
-    "typescript": "^2.5.2",
+    "typescript": "^2.6",
     "aws-sdk": "^2.7.0"
   },
   "peerDependencies": {

--- a/packages/dynamodb-data-mapper-annotations/package.json
+++ b/packages/dynamodb-data-mapper-annotations/package.json
@@ -22,7 +22,7 @@
     "@types/uuid": "^3.0.0",
     "aws-sdk": "^2.7.0",
     "jest": "^20.0.4",
-    "typescript": "^2.5.2"
+    "typescript": "^2.6"
   },
   "dependencies": {
     "@aws/dynamodb-auto-marshaller": "^0.1.0",

--- a/packages/dynamodb-data-mapper-annotations/package.json
+++ b/packages/dynamodb-data-mapper-annotations/package.json
@@ -17,11 +17,11 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^20.0.2",
+    "@types/jest": "^21",
     "@types/node": "^8.0.4",
     "@types/uuid": "^3.0.0",
     "aws-sdk": "^2.7.0",
-    "jest": "^20.0.4",
+    "jest": "^21",
     "typescript": "^2.6"
   },
   "dependencies": {

--- a/packages/dynamodb-data-mapper/.gitignore
+++ b/packages/dynamodb-data-mapper/.gitignore
@@ -1,0 +1,1 @@
+!jest.integration.js

--- a/packages/dynamodb-data-mapper/jest.integration.js
+++ b/packages/dynamodb-data-mapper/jest.integration.js
@@ -1,0 +1,7 @@
+module.exports = {
+    collectCoverage: true,
+    mapCoverage: true,
+    testMatch: [
+        '**/?(*.)(integ).js'
+    ]
+};

--- a/packages/dynamodb-data-mapper/package.json
+++ b/packages/dynamodb-data-mapper/package.json
@@ -17,10 +17,10 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^20.0.2",
+    "@types/jest": "^21",
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
-    "jest": "^20.0.4",
+    "jest": "^21",
     "typescript": "^2.6"
   },
   "dependencies": {

--- a/packages/dynamodb-data-mapper/package.json
+++ b/packages/dynamodb-data-mapper/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
     "jest": "^20.0.4",
-    "typescript": "^2.5.2"
+    "typescript": "^2.6"
   },
   "dependencies": {
     "@aws/dynamodb-data-marshaller": "^0.1.1",

--- a/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
@@ -1551,6 +1551,73 @@ describe('DataMapper', () => {
                     }
                 });
         });
+
+        it('should allow the page size to be set', () => {
+            const results =  mapper.scan({
+                valueConstructor: class {
+                    get [DynamoDbTable]() { return 'foo'; }
+                    get [DynamoDbSchema]() {
+                        return {
+                            snap: {
+                                type: 'String',
+                                keyType: 'HASH',
+                            },
+                        };
+                    }
+                },
+                pageSize: 20
+            });
+
+            results.next();
+
+            expect(mockDynamoDbClient.scan.mock.calls[0][0])
+                .toMatchObject({Limit: 20});
+        });
+
+        it('should allow the page size to be set using the deprecated "limit" parameter', () => {
+            const results =  mapper.scan({
+                valueConstructor: class {
+                    get [DynamoDbTable]() { return 'foo'; }
+                    get [DynamoDbSchema]() {
+                        return {
+                            snap: {
+                                type: 'String',
+                                keyType: 'HASH',
+                            },
+                        };
+                    }
+                },
+                limit: 20
+            });
+
+            results.next();
+
+            expect(mockDynamoDbClient.scan.mock.calls[0][0])
+                .toMatchObject({Limit: 20});
+        });
+
+        it('should prefer the "pageSize" parameter over the "limit" parameter', () => {
+            const results =  mapper.scan({
+                valueConstructor: class {
+                    get [DynamoDbTable]() { return 'foo'; }
+                    get [DynamoDbSchema]() {
+                        return {
+                            snap: {
+                                type: 'String',
+                                keyType: 'HASH',
+                            },
+                        };
+                    }
+                },
+                pageSize: 20,
+                limit: 200,
+            });
+
+            results.next();
+
+            expect(mockDynamoDbClient.scan.mock.calls[0][0])
+                .toMatchObject({Limit: 20});
+        });
     });
 
     describe('#update', () => {

--- a/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
@@ -3,7 +3,6 @@ import {
     DynamoDbSchema,
     DynamoDbTable,
 } from "./protocols";
-import {BinaryValue} from '@aws/dynamodb-auto-marshaller';
 import {Schema} from "@aws/dynamodb-data-marshaller";
 import {
     AttributePath,
@@ -12,6 +11,9 @@ import {
     FunctionExpression,
     inList,
 } from "@aws/dynamodb-expressions";
+import {ItemNotFoundException} from "./ItemNotFoundException";
+
+type BinaryValue = ArrayBuffer|ArrayBufferView;
 
 describe('DataMapper', () => {
     describe('#delete', () => {
@@ -34,9 +36,9 @@ describe('DataMapper', () => {
             async () => {
                 await expect(mapper.delete({item: {
                     [DynamoDbTable]: 'foo',
-                }})).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
-                });
+                }})).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
+                ));
             }
         );
 
@@ -45,9 +47,9 @@ describe('DataMapper', () => {
             async () => {
                 await expect(mapper.delete({item: {
                     [DynamoDbSchema]: {},
-                }})).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
-                });
+                }})).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
+                ));
             }
         );
 
@@ -391,9 +393,9 @@ describe('DataMapper', () => {
             async () => {
                 await expect(mapper.get({item: {
                     [DynamoDbTable]: 'foo',
-                }})).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
-                });
+                }})).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
+                ));
             }
         );
 
@@ -402,9 +404,9 @@ describe('DataMapper', () => {
             async () => {
                 await expect(mapper.get({item: {
                     [DynamoDbSchema]: {},
-                }})).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
-                });
+                }})).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
+                ));
             }
         );
 
@@ -617,18 +619,16 @@ describe('DataMapper', () => {
                     },
                     readConsistency: 'strong',
                     projection: ['fizz', 'pop'],
-                })).rejects.toMatchObject({
-                    itemSought: {
-                        TableName: 'foo',
-                        Key: {foo: {S: 'buzz'}},
-                        ConsistentRead: true,
-                        ProjectionExpression: '#attr0, #attr1',
-                        ExpressionAttributeNames: {
-                            '#attr0': 'foo',
-                            '#attr1': 'pop',
-                        },
-                    }
-                });
+                })).rejects.toMatchObject(new ItemNotFoundException({
+                    TableName: 'foo',
+                    Key: {foo: {S: 'buzz'}},
+                    ConsistentRead: true,
+                    ProjectionExpression: '#attr0, #attr1',
+                    ExpressionAttributeNames: {
+                        '#attr0': 'foo',
+                        '#attr1': 'pop',
+                    },
+                }));
             }
         );
 
@@ -684,9 +684,9 @@ describe('DataMapper', () => {
             async () => {
                 await expect(mapper.put({item: {
                     [DynamoDbTable]: 'foo',
-                }})).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
-                });
+                }})).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
+                ));
             }
         );
 
@@ -695,9 +695,9 @@ describe('DataMapper', () => {
             async () => {
                 await expect(mapper.put({item: {
                     [DynamoDbSchema]: {},
-                }})).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
-                });
+                }})).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
+                ));
             }
         );
 
@@ -1024,9 +1024,9 @@ describe('DataMapper', () => {
                         foo: 'buzz'
                     },
                 });
-                await expect(iter.next()).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
-                });
+                await expect(iter.next()).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
+                ));
             }
         );
 
@@ -1042,9 +1042,9 @@ describe('DataMapper', () => {
                     },
                 });
 
-                await expect(iter.next()).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
-                });
+                await expect(iter.next()).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
+                ));
             }
         );
 
@@ -1359,9 +1359,9 @@ describe('DataMapper', () => {
                         get [DynamoDbTable]() { return 'foo'; }
                     },
                 });
-                await expect(iter.next()).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
-                });
+                await expect(iter.next()).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
+                ));
             }
         );
 
@@ -1374,9 +1374,9 @@ describe('DataMapper', () => {
                     },
                 });
 
-                await expect(iter.next()).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
-                });
+                await expect(iter.next()).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
+                ));
             }
         );
 
@@ -1623,9 +1623,9 @@ describe('DataMapper', () => {
             async () => {
                 await expect(mapper.update({item: {
                     [DynamoDbTable]: 'foo',
-                }})).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
-                });
+                }})).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbDocument protocol. No object property was found at the `DynamoDbSchema` symbol'
+                ));
             }
         );
 
@@ -1634,9 +1634,9 @@ describe('DataMapper', () => {
             async () => {
                 await expect(mapper.update({item: {
                     [DynamoDbSchema]: {},
-                }})).rejects.toMatchObject({
-                    message: 'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
-                });
+                }})).rejects.toMatchObject(new Error(
+                    'The provided item did not adhere to the DynamoDbTable protocol. No string property was found at the `DynamoDbTable` symbol'
+                ));
             }
         );
 
@@ -1788,9 +1788,9 @@ describe('DataMapper', () => {
                         },
                     },
                 },
-            })).rejects.toMatchObject({
-                message: 'Update operation completed successfully, but the updated value was not returned'
-            });
+            })).rejects.toMatchObject(new Error(
+                'Update operation completed successfully, but the updated value was not returned'
+            ));
         });
 
         describe('version attributes', () => {

--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -268,6 +268,7 @@ export class DataMapper {
         indexName,
         keyCondition,
         limit,
+        pageSize = limit,
         projection,
         readConsistency = this.readConsistency,
         scanIndexForward,
@@ -278,7 +279,7 @@ export class DataMapper {
             TableName: this.tableNamePrefix + getTableName(valueConstructor.prototype),
             ConsistentRead: readConsistency === 'strong',
             ScanIndexForward: scanIndexForward,
-            Limit: limit,
+            Limit: pageSize,
             IndexName: indexName,
         };
 
@@ -340,6 +341,7 @@ export class DataMapper {
         filter,
         indexName,
         limit,
+        pageSize = limit,
         projection,
         readConsistency = this.readConsistency,
         startKey,
@@ -348,7 +350,7 @@ export class DataMapper {
         const req: ScanInput = {
             TableName: this.tableNamePrefix + getTableName(valueConstructor.prototype),
             ConsistentRead: readConsistency === 'strong',
-            Limit: limit,
+            Limit: pageSize,
             IndexName: indexName,
         };
 

--- a/packages/dynamodb-data-mapper/src/namedParameters.ts
+++ b/packages/dynamodb-data-mapper/src/namedParameters.ts
@@ -128,8 +128,15 @@ export interface QueryParameters<T extends StringToAnyObjectMap = StringToAnyObj
 
     /**
      * The maximum number of items to fetch per page of results.
+     *
+     * @deprecated
      */
     limit?: number;
+
+    /**
+     * The maximum number of items to fetch per page of results.
+     */
+    pageSize?: number;
 
     /**
      * The item attributes to get.
@@ -185,8 +192,15 @@ export interface ScanParameters<T extends StringToAnyObjectMap = StringToAnyObje
 
     /**
      * The maximum number of items to fetch per page of results.
+     *
+     * @deprecated
      */
     limit?: number;
+
+    /**
+     * The maximum number of items to fetch per page of results.
+     */
+    pageSize?: number;
 
     /**
      * The item attributes to get.

--- a/packages/dynamodb-data-marshaller/package.json
+++ b/packages/dynamodb-data-marshaller/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
     "jest": "^20.0.4",
-    "typescript": "^2.5.2"
+    "typescript": "^2.6"
   },
   "dependencies": {
     "@aws/dynamodb-auto-marshaller": "^0.1.0",

--- a/packages/dynamodb-data-marshaller/package.json
+++ b/packages/dynamodb-data-marshaller/package.json
@@ -15,10 +15,10 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^20.0.2",
+    "@types/jest": "^21",
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
-    "jest": "^20.0.4",
+    "jest": "^21",
     "typescript": "^2.6"
   },
   "dependencies": {

--- a/packages/dynamodb-expressions/package.json
+++ b/packages/dynamodb-expressions/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
     "jest": "^20.0.4",
-    "typescript": "^2.5.2"
+    "typescript": "^2.6"
   },
   "peerDependencies": {
     "aws-sdk": "^2.7.0"

--- a/packages/dynamodb-expressions/package.json
+++ b/packages/dynamodb-expressions/package.json
@@ -15,10 +15,10 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^20.0.2",
+    "@types/jest": "^21",
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
-    "jest": "^20.0.4",
+    "jest": "^21",
     "typescript": "^2.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR bumps the required version on a few devDependencies and replaces the `limit` parameter with `pageSize` for both `query` and `scan` operations.

Rather than use `limit` to bound the iterator returned, it is kept as an alias for `pageSize` for backwards compatibility. 

Resolves #6 