### PR TITLE
Fix/always return persisted value from put

### DIFF
--- a/packages/dynamodb-data-mapper/CHANGELOG.md
+++ b/packages/dynamodb-data-mapper/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Removed
+ - **BREAKING CHANGE**: Removed the `returnValues` parameter from `put`. `put`
+    will now always return the value that was persisted, thereby providing
+    access to injected defaults and accurate version numbers.
+
+### Added
+ - Add a `parallelScan` method to the DataMapper.
+ - Add optional parameters to the `scan` method to allow its use as a parallel
+    scan worker
+ - Add a `pageSize` parameter to `query` and `scan` to limit the size of pages
+    fetched during a read. `pageSize` was previously called `limit`.
+
+### Changed
+ - Use TSLib instead of having TypeScript generate helpers to reduce bundle size
+
+### Deprecated
+ - Deprecate `limit` parameter on `query` and `scan`. It has been renamed to
+    `pageSize`, though a value provided for `limit` will still be used if no
+    `pageSize` parameter is provided.
+
+## [0.1.1]
+### Fixed
+ - Update dependency version to match released version identifier
+
+## [0.1.0]
+Initial release

--- a/packages/dynamodb-data-mapper/src/DataMapper.integ.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.integ.ts
@@ -76,8 +76,8 @@ describe('DataMapper', () => {
                     }
                 ],
                 ProvisionedThroughput: {
-                    ReadCapacityUnits: 50,
-                    WriteCapacityUnits: 50,
+                    ReadCapacityUnits: 5,
+                    WriteCapacityUnits: 5,
                 },
             })
                 .promise(),
@@ -112,9 +112,9 @@ describe('DataMapper', () => {
             },
         };
 
-        await mapper.put({item});
+        expect(await mapper.put({item})).toEqual(item);
 
-        expect(await mapper.get({item}))
+        expect(await mapper.get({item, readConsistency: 'strong'}))
             .toEqual(item);
     });
 

--- a/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
@@ -940,40 +940,30 @@ describe('DataMapper', () => {
             }
         );
 
-        it('should unmarshall any returned attributes', async () => {
-            promiseFunc.mockImplementation(() => Promise.resolve({Attributes: {
-                fizz: {S: 'buzz'},
-                bar: {NS: ['1', '2', '3']},
-                baz: {L: [{BOOL: true}, {N: '4'}]}
-            }}));
+        it('should return the unmarshalled input', async () => {
+            promiseFunc.mockImplementation(() => Promise.resolve({}));
 
             const result = await mapper.put({
                 item: {
-                    foo: 'buzz',
                     [DynamoDbTable]: 'foo',
                     [DynamoDbSchema]: {
                         foo: {
                             type: 'String',
                             attributeName: 'fizz',
+                            defaultProvider: () => 'keykey',
                             keyType: 'HASH',
                         },
                         bar: {
-                            type: 'Set',
-                            memberType: 'Number'
-                        },
-                        baz: {
-                            type: 'Tuple',
-                            members: [{type: 'Boolean'}, {type: 'Number'}]
+                            type: 'Number',
+                            versionAttribute: true
                         },
                     },
-                },
-                returnValues: "ALL_OLD"
+                }
             });
 
-            expect(result).toEqual({
-                foo: 'buzz',
-                bar: new Set([1, 2, 3]),
-                baz: [true, 4],
+            expect(result).toMatchObject({
+                foo: 'keykey',
+                bar: 0
             })
         });
     });

--- a/packages/dynamodb-data-mapper/src/namedParameters.ts
+++ b/packages/dynamodb-data-mapper/src/namedParameters.ts
@@ -90,11 +90,6 @@ export interface PutParameters<T extends StringToAnyObjectMap = StringToAnyObjec
     condition?: ConditionExpression;
 
     /**
-     * The values to return from this operation.
-     */
-    returnValues?: 'ALL_OLD'|'NONE';
-
-    /**
      * Whether this operation should NOT honor the version attribute specified
      * in the schema by incrementing the attribute and preventing the operation
      * from taking effect if the local version is out of date.


### PR DESCRIPTION
This PR removes the `returnValues` parameter from `put` and instead always return an unmarshalled form of the value as it was persisted to DynamoDB. This means the return will have values with defaults resolved (such as properties annotated with `autoGeneratedHashKey`) and other values appropriately normalized.

Resolves #9 