### PR TITLE
Ensure retried writes are only yielded once

### DIFF
--- a/packages/dynamodb-batch-iterator/CHANGELOG.md
+++ b/packages/dynamodb-batch-iterator/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixed
+ - When the source for a batch operation is a synchronous iterable, exhaust the
+    source before interleaving throttled items.
+ - When a write is returned as unprocessed, do not yield the marshalled form.
+
+## [0.3.0]
+Initial release

--- a/packages/dynamodb-batch-iterator/src/BatchGet.ts
+++ b/packages/dynamodb-batch-iterator/src/BatchGet.ts
@@ -4,7 +4,7 @@ import { SyncOrAsyncIterable, TableState } from './types';
 import { AttributeMap, BatchGetItemInput } from 'aws-sdk/clients/dynamodb';
 import DynamoDB = require('aws-sdk/clients/dynamodb');
 
-const MAX_READ_BATCH_SIZE = 100;
+export const MAX_READ_BATCH_SIZE = 100;
 
 /**
  * Retrieves items from DynamoDB in batches of 100 or fewer via one or more

--- a/packages/dynamodb-batch-iterator/src/BatchOperation.ts
+++ b/packages/dynamodb-batch-iterator/src/BatchOperation.ts
@@ -201,10 +201,12 @@ export abstract class BatchOperation<
             !this.sourceDone &&
             this.toSend.length < this.batchSize
         ) {
-            const toProcess = await Promise.race([
-                this.sourceNext,
-                Promise.race(this.throttled)
-            ]);
+            const toProcess = isIteratorResult(this.sourceNext)
+                ? this.sourceNext
+                : await Promise.race([
+                    this.sourceNext,
+                    Promise.race(this.throttled)
+                ]);
 
             if (isIteratorResult(toProcess)) {
                 this.sourceDone = toProcess.done;

--- a/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
@@ -311,7 +311,7 @@ describe('DataMapper', () => {
                         projection: ['snap.pop', 'mixedList[2]']
                     }
                 }
-            }
+            };
 
             for await (const _ of mapper.batchGet(gets, config)) {
                 // pass


### PR DESCRIPTION
There is a bug in the way unprocessed items are filtered from the items yielded by `BatchWrite`. `Array.prototype.filter` is used and its result is not captured, so the item will be yielded as if it succeeded.

This PR updates `BatchWrite` to filter the array in place and updates the tests to ensure the iterator yields the proper results.