### PR TITLE
Remove dom lib from typings

### DIFF
--- a/packages/dynamodb-auto-marshaller/tsconfig.json
+++ b/packages/dynamodb-auto-marshaller/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
-      "dom",
       "es5",
       "es2015.iterable",
       "es2015.promise",

--- a/packages/dynamodb-batch-iterator/tsconfig.json
+++ b/packages/dynamodb-batch-iterator/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
-      "dom",
       "es5",
       "es2015.iterable",
       "es2015.promise",

--- a/packages/dynamodb-data-mapper-annotations/tsconfig.json
+++ b/packages/dynamodb-data-mapper-annotations/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
-      "dom",
       "es5",
       "es2015.iterable",
       "es2015.promise",

--- a/packages/dynamodb-data-mapper/tsconfig.json
+++ b/packages/dynamodb-data-mapper/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
-      "dom",
       "es5",
       "es2015.iterable",
       "es2015.promise",

--- a/packages/dynamodb-data-marshaller/src/KeySchema.ts
+++ b/packages/dynamodb-data-marshaller/src/KeySchema.ts
@@ -1,3 +1,5 @@
+import { KeyType } from './SchemaType';
+
 export interface AttributeTypeMap {
     [attributeName: string]: ScalarAttributeType;
 }

--- a/packages/dynamodb-data-marshaller/tsconfig.json
+++ b/packages/dynamodb-data-marshaller/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
-      "dom",
       "es5",
       "es2015.iterable",
       "es2015.promise",

--- a/packages/dynamodb-expressions/tsconfig.json
+++ b/packages/dynamodb-expressions/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
-      "dom",
       "es5",
       "es2015.iterable",
       "es2015.promise",


### PR DESCRIPTION
This PR removes the `"dom"` lib from all package's tsonfig files. This was previously required by TypeDoc, but that requirement has been removed. This PR ensures no package includes DOM typings, which caused a test that should have failed to pass.