### PR TITLE
Ensure only key properties are serialized in the ExclusiveStartKey property of Query- and ScanInput structures

### DIFF
--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -846,7 +846,7 @@ export class DataMapper {
         }
 
         if (startKey) {
-            req.ExclusiveStartKey = marshallItem(schema, startKey);
+            req.ExclusiveStartKey = marshallKey(schema, startKey);
         }
 
         let result: QueryOutput;
@@ -1085,7 +1085,7 @@ export class DataMapper {
         }
 
         if (startKey) {
-            req.ExclusiveStartKey = marshallItem(schema, startKey);
+            req.ExclusiveStartKey = marshallKey(schema, startKey);
         }
 
         return req;


### PR DESCRIPTION
Non-key properties should be ignored, and `defaultProvider` functions for such properties should not be invoked.

Fixes #39 