### PR TITLE
use the valueConstructor to construct returned query items

### DIFF
--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -855,7 +855,7 @@ export class DataMapper {
             req.ExclusiveStartKey = result.LastEvaluatedKey;
             if (result.Items) {
                 for (const item of result.Items) {
-                    yield unmarshallItem<T>(schema, item);
+                    yield unmarshallItem<T>(schema, item, valueConstructor);
                 }
             }
         } while (result.LastEvaluatedKey !== undefined);


### PR DESCRIPTION
query calls `unmarshallItem` to create the items it returns, but does not pass the `valueConstructor` to it.

This means unmarshallItem does return the data items, but in a plain object, not in the correct Class.

There are no tests for whether or not it yields the correct classes.