### PR TITLE
Ensure query and scan marshall start keys using the correct index

### DIFF
--- a/packages/dynamodb-data-mapper/CHANGELOG.md
+++ b/packages/dynamodb-data-mapper/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.4.2]
+### Fixed
+ - Ensure `query` and `scan` marshall exclusive start keys for the specified
+    index.
+
 ## [0.4.1]
 ### Fixed
  - Ensure `query` returns instances of the provided model class.

--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -846,7 +846,7 @@ export class DataMapper {
         }
 
         if (startKey) {
-            req.ExclusiveStartKey = marshallKey(schema, startKey);
+            req.ExclusiveStartKey = marshallKey(schema, startKey, indexName);
         }
 
         let result: QueryOutput;
@@ -1085,7 +1085,7 @@ export class DataMapper {
         }
 
         if (startKey) {
-            req.ExclusiveStartKey = marshallKey(schema, startKey);
+            req.ExclusiveStartKey = marshallKey(schema, startKey, indexName);
         }
 
         return req;


### PR DESCRIPTION
This change ensures the key marshaller for `query` and `scan` is provided with the correct index name. Should resolve #45 