### PR TITLE
Add `executeUpdateExprssion` method to `DataMapper`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
     collectCoverage: true,
-    mapCoverage: true
 };

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.5.1",
+  "lerna": "2.11.0",
   "version": "0.4.2",
   "hoist": true
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^21",
+    "@types/jest": "^22",
     "@types/node": "^8.0.4",
-    "jest": "^21",
+    "jest": "^22",
     "lerna": "^2.5.1",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"

--- a/packages/dynamodb-auto-marshaller/package.json
+++ b/packages/dynamodb-auto-marshaller/package.json
@@ -28,10 +28,10 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^21",
+    "@types/jest": "^22",
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
-    "jest": "^21",
+    "jest": "^22",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-batch-iterator/package.json
+++ b/packages/dynamodb-batch-iterator/package.json
@@ -28,10 +28,10 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^21",
+    "@types/jest": "^22",
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
-    "jest": "^21",
+    "jest": "^22",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-data-mapper-annotations/package.json
+++ b/packages/dynamodb-data-mapper-annotations/package.json
@@ -30,11 +30,11 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^21",
+    "@types/jest": "^22",
     "@types/node": "^8.0.4",
     "@types/uuid": "^3.0.0",
     "aws-sdk": "^2.7.0",
-    "jest": "^21",
+    "jest": "^22",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-data-mapper/package.json
+++ b/packages/dynamodb-data-mapper/package.json
@@ -30,14 +30,15 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^21",
+    "@types/jest": "^22",
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
-    "jest": "^21",
+    "jest": "^22",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },
   "dependencies": {
+    "@aws/dynamodb-auto-marshaller": "^0.4.1",
     "@aws/dynamodb-batch-iterator": "^0.4.1",
     "@aws/dynamodb-data-marshaller": "^0.4.1",
     "@aws/dynamodb-expressions": "^0.4.1",

--- a/packages/dynamodb-data-mapper/src/namedParameters/ExecuteUpdateExpressionOptions.ts
+++ b/packages/dynamodb-data-mapper/src/namedParameters/ExecuteUpdateExpressionOptions.ts
@@ -1,0 +1,9 @@
+import { ConditionExpression } from '@aws/dynamodb-expressions';
+
+export interface ExecuteUpdateExpressionOptions {
+    /**
+     * A condition on which this update operation's completion will be
+     * predicated.
+     */
+    condition?: ConditionExpression;
+}

--- a/packages/dynamodb-data-mapper/src/namedParameters/index.ts
+++ b/packages/dynamodb-data-mapper/src/namedParameters/index.ts
@@ -2,6 +2,7 @@ export * from './BatchGetOptions';
 export * from './CreateTableOptions';
 export * from './DataMapperConfiguration';
 export * from './DeleteOptions';
+export * from './ExecuteUpdateExpressionOptions';
 export * from './GetOptions';
 export * from './ProvisionedThroughput';
 export * from './PutOptions';

--- a/packages/dynamodb-data-marshaller/package.json
+++ b/packages/dynamodb-data-marshaller/package.json
@@ -28,10 +28,10 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^21",
+    "@types/jest": "^22",
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
-    "jest": "^21",
+    "jest": "^22",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-data-marshaller/src/index.ts
+++ b/packages/dynamodb-data-marshaller/src/index.ts
@@ -3,6 +3,7 @@ export * from './InvalidValueError';
 export * from './isKey';
 export * from './KeySchema';
 export * from './keysFromSchema';
+export * from './marshallExpression';
 export * from './marshallItem';
 export * from './marshallKey';
 export * from './Schema';

--- a/packages/dynamodb-data-marshaller/src/keysFromSchema.ts
+++ b/packages/dynamodb-data-marshaller/src/keysFromSchema.ts
@@ -9,7 +9,6 @@ import {
     BinaryType,
     CustomType,
     DateType,
-    KeyType,
     NumberType,
     StringType,
 } from './SchemaType';

--- a/packages/dynamodb-data-marshaller/src/marshallExpression.spec.ts
+++ b/packages/dynamodb-data-marshaller/src/marshallExpression.spec.ts
@@ -1,0 +1,226 @@
+import {
+    marshallConditionExpression,
+    marshallFunctionExpression,
+    marshallMathematicalExpression,
+    marshallProjectionExpression,
+    marshallUpdateExpression,
+} from './marshallExpression';
+import { Schema } from './Schema';
+import {
+    AttributePath,
+    FunctionExpression,
+    MathematicalExpression,
+    UpdateExpression,
+} from '@aws/dynamodb-expressions';
+
+const schema: Schema = {
+    foo: {
+        type: 'String',
+        attributeName: 'bar',
+    },
+    fizz: {
+        type: 'Number',
+        attributeName: 'buzz',
+    },
+    nested: {
+        type: 'Document',
+        attributeName: 'nested_level_1',
+        members: {
+            nested: {
+                type: 'Document',
+                attributeName: 'nested_level_2',
+                members: {
+                    scalar: {
+                        type: 'String',
+                        attributeName: 'nested_scalar'
+                    },
+                },
+            },
+        },
+    },
+};
+
+describe('marshallConditionExpression', () => {
+    it('should map nested keys to their attributeName equivalents in simple conditions', () => {
+        expect(marshallConditionExpression(
+            {type: 'Equals', subject: 'foo', object: 'baz'},
+            schema
+        )).toEqual({
+            expression: '#attr0 = :val1',
+            ExpressionAttributeNames: { '#attr0': 'bar' },
+            ExpressionAttributeValues: { ':val1': { 'S': 'baz' } },
+        })
+    });
+
+    it('should map nested keys to their attributeName equivalents in bounding conditions', () => {
+        expect(marshallConditionExpression(
+            {type: 'Between', subject: 'fizz', lowerBound: 1, upperBound: 5},
+            schema
+        )).toEqual({
+            expression: '#attr0 BETWEEN :val1 AND :val2',
+            ExpressionAttributeNames: { '#attr0': 'buzz' },
+            ExpressionAttributeValues: {
+                ':val1': { 'N': '1' },
+                ':val2': { 'N': '5' },
+            },
+        })
+    });
+
+    it('should map nested keys to their attributeName equivalents in membership conditions', () => {
+        expect(marshallConditionExpression(
+            {type: 'Membership', subject: 'foo', values: ['bar', 'baz', 'quux']},
+            schema
+        )).toEqual({
+            expression: '#attr0 IN (:val1, :val2, :val3)',
+            ExpressionAttributeNames: { '#attr0': 'bar' },
+            ExpressionAttributeValues: {
+                ':val1': { 'S': 'bar' },
+                ':val2': { 'S': 'baz' },
+                ':val3': { 'S': 'quux' },
+            },
+        })
+    });
+
+    it('should map nested keys to their attributeName equivalents in negated conditions', () => {
+        expect(marshallConditionExpression(
+            {type: 'Not', condition: {type: 'Equals', subject: 'foo', object: 'baz'}},
+            schema
+        )).toEqual({
+            expression: 'NOT (#attr0 = :val1)',
+            ExpressionAttributeNames: { '#attr0': 'bar' },
+            ExpressionAttributeValues: { ':val1': { 'S': 'baz' } },
+        })
+    });
+
+    it('should map nested keys to their attributeName equivalents in compound conditions', () => {
+        expect(marshallConditionExpression(
+            {
+                type: 'And',
+                conditions: [
+                    {type: 'Equals', subject: 'foo', object: 'baz'},
+                    {type: 'Between', subject: 'fizz', lowerBound: 1, upperBound: 5},
+                ]
+            },
+            schema
+        )).toEqual({
+            expression: '(#attr0 = :val1) AND (#attr2 BETWEEN :val3 AND :val4)',
+            ExpressionAttributeNames: {
+                '#attr0': 'bar',
+                '#attr2': 'buzz',
+            },
+            ExpressionAttributeValues: {
+                ':val1': { 'S': 'baz' },
+                ':val3': { 'N': '1' },
+                ':val4': { 'N': '5' },
+            },
+        })
+    });
+
+    it('should handle function conditions', () => {
+        expect(marshallConditionExpression(
+            new FunctionExpression('attributeExists', new AttributePath('nested.nested.scalar')),
+            schema
+        )).toEqual({
+            expression: 'attributeExists(#attr0.#attr1.#attr2)',
+            ExpressionAttributeNames: {
+                '#attr0': 'nested_level_1',
+                '#attr1': 'nested_level_2',
+                '#attr2': 'nested_scalar',
+            },
+            ExpressionAttributeValues: {},
+        })
+    });
+});
+
+describe('marshallFunctionExpression', () => {
+    it('should map nested keys to their attributeName equivalents', () => {
+        expect(marshallFunctionExpression(
+            new FunctionExpression('attributeExists', new AttributePath('nested.nested.scalar')),
+            schema
+        )).toEqual({
+            expression: 'attributeExists(#attr0.#attr1.#attr2)',
+            ExpressionAttributeNames: {
+                '#attr0': 'nested_level_1',
+                '#attr1': 'nested_level_2',
+                '#attr2': 'nested_scalar',
+            },
+            ExpressionAttributeValues: {},
+        })
+    });
+
+    it('should not map non-path arguments', () => {
+        expect(marshallFunctionExpression(
+            new FunctionExpression('beginsWith', new AttributePath('nested.nested.scalar'), 'foo'),
+            schema
+        )).toEqual({
+            expression: 'beginsWith(#attr0.#attr1.#attr2, :val3)',
+            ExpressionAttributeNames: {
+                '#attr0': 'nested_level_1',
+                '#attr1': 'nested_level_2',
+                '#attr2': 'nested_scalar',
+            },
+            ExpressionAttributeValues: {
+                ':val3': {'S': 'foo'},
+            },
+        })
+    })
+});
+
+describe('marshallMathematicalExpression', () => {
+    it('should map nested keys to their attributeName equivalents', () => {
+        expect(marshallMathematicalExpression(
+            new MathematicalExpression('fizz', '-', 2),
+            schema
+        )).toEqual({
+            expression: '#attr0 - :val1',
+            ExpressionAttributeNames: {
+                '#attr0': 'buzz',
+            },
+            ExpressionAttributeValues: {
+                ':val1': {'N': '2'}
+            },
+        })
+    });
+});
+
+describe('marshallProjectionExpression', () => {
+    it('should map nested keys to their attributeName equivalents', () => {
+        expect(marshallProjectionExpression(
+            [new AttributePath('nested.nested.scalar'), 'fizz'],
+            schema
+        )).toEqual({
+            expression: '#attr0.#attr1.#attr2, #attr3',
+            ExpressionAttributeNames: {
+                '#attr0': 'nested_level_1',
+                '#attr1': 'nested_level_2',
+                '#attr2': 'nested_scalar',
+                '#attr3': 'buzz',
+            },
+            ExpressionAttributeValues: {},
+        })
+    });
+});
+
+describe('marshallUpdateExpression', () => {
+    it('should map nested keys to their attributeName equivalents', () => {
+        const expr = new UpdateExpression;
+        expr.set(new AttributePath('nested.nested.scalar'), 'boo');
+        expr.add('fizz', 1);
+        expr.remove('foo');
+
+        expect(marshallUpdateExpression(expr, schema)).toEqual({
+            expression: 'ADD #attr0 :val1 SET #attr2.#attr3.#attr4 = :val5 REMOVE #attr6',
+            ExpressionAttributeNames: {
+                '#attr2': 'nested_level_1',
+                '#attr3': 'nested_level_2',
+                '#attr4': 'nested_scalar',
+                '#attr0': 'buzz',
+                '#attr6': 'bar'
+            },
+            ExpressionAttributeValues: {
+                ':val5': {S: 'boo'},
+                ':val1': {N: '1'},
+            },
+        })
+    });
+});

--- a/packages/dynamodb-data-marshaller/src/marshallExpression.ts
+++ b/packages/dynamodb-data-marshaller/src/marshallExpression.ts
@@ -1,0 +1,276 @@
+import { Schema } from './Schema';
+import { toSchemaName } from './toSchemaName';
+import {
+    ExpressionAttributeNameMap,
+    ExpressionAttributeValueMap,
+} from 'aws-sdk/clients/dynamodb';
+import {
+    AttributePath,
+    ConditionExpression,
+    FunctionExpression,
+    MathematicalExpression,
+    ProjectionExpression,
+    UpdateExpression,
+    ExpressionAttributes,
+    serializeConditionExpression,
+    serializeProjectionExpression,
+} from '@aws/dynamodb-expressions';
+
+/**
+ * A DynamoDB expression serialized to a string and accompanied by the name and
+ * value substitutions that have been performed during serialization.
+ */
+export interface MarshalledExpression {
+    /**
+     * A serialized expression.
+     */
+    expression: string;
+
+    /**
+     * A map of name tokens => the property name for which the token has been
+     * substituted in the serialized expression.
+     */
+    ExpressionAttributeNames: ExpressionAttributeNameMap;
+
+    /**
+     * A map of value tokens => the value for which the token has been
+     * substituted in the serialized expression.
+     */
+    ExpressionAttributeValues: ExpressionAttributeValueMap;
+}
+
+/**
+ * Serialize a condition expression, substituting any property names for the
+ * corresponding attribute names in the provided schema.
+ *
+ * @param expression The expression object to marshall.
+ * @param schema The schema of the table to which the expression pertains.
+ * @param attributes An optional ExpressionAttributes object to synchronize
+ *                      substitutions across multiple expressions.
+ */
+export function marshallConditionExpression(
+    expression: ConditionExpression,
+    schema: Schema,
+    attributes: ExpressionAttributes = new ExpressionAttributes
+): MarshalledExpression {
+    const serialized = serializeConditionExpression(
+        normalizeConditionExpression(expression, schema),
+        attributes
+    );
+
+    return {
+        expression: serialized,
+        ExpressionAttributeNames: attributes.names,
+        ExpressionAttributeValues: attributes.values,
+    };
+}
+
+/**
+ * Serialize a function expression, substituting any property names for the
+ * corresponding attribute names in the provided schema.
+ *
+ * @param expression The expression object to marshall.
+ * @param schema The schema of the table to which the expression pertains.
+ * @param attributes An optional ExpressionAttributes object to synchronize
+ *                      substitutions across multiple expressions.
+ */
+export function marshallFunctionExpression(
+    expression: FunctionExpression,
+    schema: Schema,
+    attributes: ExpressionAttributes = new ExpressionAttributes
+): MarshalledExpression {
+    const serialized = normalizeFunctionExpression(expression, schema)
+        .serialize(attributes);
+
+    return {
+        expression: serialized,
+        ExpressionAttributeNames: attributes.names,
+        ExpressionAttributeValues: attributes.values,
+    };
+}
+
+/**
+ * Serialize a mathematical expression, substituting any property names for the
+ * corresponding attribute names in the provided schema.
+ *
+ * @param expression The expression object to marshall.
+ * @param schema The schema of the table to which the expression pertains.
+ * @param attributes An optional ExpressionAttributes object to synchronize
+ *                      substitutions across multiple expressions.
+ */
+export function marshallMathematicalExpression(
+    expression: MathematicalExpression,
+    schema: Schema,
+    attributes: ExpressionAttributes = new ExpressionAttributes
+): MarshalledExpression {
+    const serialized = normalizeMathematicalExpression(expression, schema)
+        .serialize(attributes);
+
+    return {
+        expression: serialized,
+        ExpressionAttributeNames: attributes.names,
+        ExpressionAttributeValues: attributes.values,
+    };
+}
+
+/**
+ * Serialize a projection expression, substituting any property names for the
+ * corresponding attribute names in the provided schema.
+ *
+ * @param expression The expression object to marshall.
+ * @param schema The schema of the table to which the expression pertains.
+ * @param attributes An optional ExpressionAttributes object to synchronize
+ *                      substitutions across multiple expressions.
+ */
+export function marshallProjectionExpression(
+    expression: ProjectionExpression,
+    schema: Schema,
+    attributes: ExpressionAttributes = new ExpressionAttributes
+): MarshalledExpression {
+    const serialized = serializeProjectionExpression(
+        expression.map(el => toSchemaName(el, schema)),
+        attributes
+    );
+
+    return {
+        expression: serialized,
+        ExpressionAttributeNames: attributes.names,
+        ExpressionAttributeValues: attributes.values,
+    };
+}
+
+/**
+ * Serialize an update expression, substituting any property names for the
+ * corresponding attribute names in the provided schema.
+ *
+ * @param expression The expression object to marshall.
+ * @param schema The schema of the table to which the expression pertains.
+ * @param attributes An optional ExpressionAttributes object to synchronize
+ *                      substitutions across multiple expressions.
+ */
+export function marshallUpdateExpression(
+    expression: UpdateExpression,
+    schema: Schema,
+    attributes: ExpressionAttributes = new ExpressionAttributes
+): MarshalledExpression {
+    const serialized = normalizeUpdateExpression(expression, schema)
+        .serialize(attributes);
+
+    return {
+        expression: serialized,
+        ExpressionAttributeNames: attributes.names,
+        ExpressionAttributeValues: attributes.values,
+    };
+}
+
+function normalizeConditionExpression(
+    expression: ConditionExpression,
+    schema: Schema
+): ConditionExpression {
+    if (FunctionExpression.isFunctionExpression(expression)) {
+        return normalizeFunctionExpression(expression, schema);
+    }
+
+    switch (expression.type) {
+        case 'Equals':
+        case 'NotEquals':
+        case 'LessThan':
+        case 'LessThanOrEqualTo':
+        case 'GreaterThan':
+        case 'GreaterThanOrEqualTo':
+            return {
+                ...expression,
+                subject: toSchemaName(expression.subject, schema),
+                object: normalizeIfPath(expression.object, schema),
+            };
+
+        case 'Between':
+            return {
+                ...expression,
+                subject: toSchemaName(expression.subject, schema),
+                lowerBound: normalizeIfPath(expression.lowerBound, schema),
+                upperBound: normalizeIfPath(expression.upperBound, schema),
+            };
+        case 'Membership':
+            return {
+                ...expression,
+                subject: toSchemaName(expression.subject, schema),
+                values: expression.values.map(arg => normalizeIfPath(arg, schema)),
+            };
+        case 'Not':
+            return {
+                ...expression,
+                condition: normalizeConditionExpression(
+                    expression.condition,
+                    schema
+                ),
+            };
+        case 'And':
+        case 'Or':
+            return {
+                ...expression,
+                conditions: expression.conditions.map(condition =>
+                    normalizeConditionExpression(condition, schema)
+                ),
+            };
+    }
+}
+
+function normalizeFunctionExpression(
+    expression: FunctionExpression,
+    schema: Schema
+): FunctionExpression {
+    return new FunctionExpression(
+        expression.name,
+        ...expression.args.map(arg => normalizeIfPath(arg, schema))
+    );
+}
+
+function normalizeMathematicalExpression(
+    expression: MathematicalExpression,
+    schema: Schema
+): MathematicalExpression {
+    return new MathematicalExpression(
+        AttributePath.isAttributePath(expression.lhs) || typeof expression.lhs === 'string'
+            ? toSchemaName(expression.lhs, schema)
+            : expression.lhs,
+        expression.operator,
+        AttributePath.isAttributePath(expression.rhs) || typeof expression.rhs === 'string'
+            ? toSchemaName(expression.rhs, schema)
+            : expression.rhs,
+    )
+}
+
+const mapsToTransform: Array<[
+    'toAdd'|'toDelete'|'toSet',
+    'add'|'delete'|'set'
+]> = [
+    ['toAdd', 'add'],
+    ['toDelete', 'delete'],
+    ['toSet', 'set'],
+];
+
+function normalizeUpdateExpression(
+    expression: UpdateExpression,
+    schema: Schema
+): UpdateExpression {
+    const normalized = new UpdateExpression;
+    for (const [dataSet, exprMethod] of mapsToTransform) {
+        for (const [path, value] of expression[dataSet]) {
+            normalized[exprMethod](toSchemaName(path, schema), value);
+        }
+    }
+    expression.toRemove.forEach(
+        el => normalized.remove(toSchemaName(el, schema))
+    );
+
+    return normalized;
+}
+
+function normalizeIfPath(path: any, schema: Schema): any {
+    if (AttributePath.isAttributePath(path)) {
+        return toSchemaName(path, schema);
+    }
+
+    return path;
+}

--- a/packages/dynamodb-data-marshaller/src/marshallItem.ts
+++ b/packages/dynamodb-data-marshaller/src/marshallItem.ts
@@ -6,8 +6,6 @@ import {AttributeMap, AttributeValue} from "aws-sdk/clients/dynamodb";
 import {
     BinarySet,
     BinaryValue,
-    EmptyHandlingStrategy,
-    InvalidHandlingStrategy,
     Marshaller,
     NumberValueSet,
 } from "@aws/dynamodb-auto-marshaller";

--- a/packages/dynamodb-data-marshaller/src/marshallItem.ts
+++ b/packages/dynamodb-data-marshaller/src/marshallItem.ts
@@ -1,14 +1,14 @@
-import {Schema} from "./Schema";
-import {SchemaType} from "./SchemaType";
-import {InvalidValueError} from "./InvalidValueError";
-import {InvalidSchemaError} from "./InvalidSchemaError";
-import {AttributeMap, AttributeValue} from "aws-sdk/clients/dynamodb";
+import { Schema } from './Schema';
+import { SchemaType } from './SchemaType';
+import { InvalidValueError } from './InvalidValueError';
+import { InvalidSchemaError } from './InvalidSchemaError';
+import { AttributeMap, AttributeValue } from 'aws-sdk/clients/dynamodb';
 import {
     BinarySet,
     BinaryValue,
     Marshaller,
     NumberValueSet,
-} from "@aws/dynamodb-auto-marshaller";
+} from '@aws/dynamodb-auto-marshaller';
 const bytes = require('utf8-bytes');
 
 /**

--- a/packages/dynamodb-data-marshaller/src/toSchemaName.ts
+++ b/packages/dynamodb-data-marshaller/src/toSchemaName.ts
@@ -1,6 +1,6 @@
-import {AttributePath} from '@aws/dynamodb-expressions';
-import {Schema} from './Schema';
-import {ListType, SchemaType} from './SchemaType';
+import { AttributePath } from '@aws/dynamodb-expressions';
+import { Schema } from './Schema';
+import { SchemaType } from './SchemaType';
 
 export function toSchemaName(
     path: AttributePath|string,

--- a/packages/dynamodb-data-marshaller/tsconfig.json
+++ b/packages/dynamodb-data-marshaller/tsconfig.json
@@ -12,6 +12,7 @@
     "importHelpers": true,
     "module": "commonjs",
     "strict": true,
+    "noUnusedLocals": true,
     "declaration": true,
     "sourceMap": true,
     "rootDir": "./src",

--- a/packages/dynamodb-expressions/package.json
+++ b/packages/dynamodb-expressions/package.json
@@ -28,10 +28,10 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^21",
+    "@types/jest": "^22",
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
-    "jest": "^21",
+    "jest": "^22",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },


### PR DESCRIPTION
This PR adds a method to the `DataMapper` to execute an arbitrary update expression. Also centralizes schema-driven expression marshalling in `@aws/dynamodb-data-marshaller` instead of using module-local functions in `DataMapper.ts`