### PR TITLE
Add package-level rollup files …

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "bootstrap": "lerna bootstrap",
     "docs": "typedoc src && lerna run docs",
     "pretest": "lerna run pretest",
+    "rollup": "lerna run rollup",
     "test": "jest"
   },
   "author": {

--- a/packages/dynamodb-auto-marshaller/package.json
+++ b/packages/dynamodb-auto-marshaller/package.json
@@ -16,10 +16,12 @@
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-auto-marshaller/",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "module": "./build/index.mjs",
   "scripts": {
     "docs": "typedoc src",
-    "prepublishOnly": "tsc",
+    "prepublishOnly": "tsc && npm run rollup",
     "pretest": "tsc -p tsconfig.test.json",
+    "rollup": "rollup -c rollup.config.js",
     "test": "jest"
   },
   "author": {
@@ -32,6 +34,8 @@
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
     "jest": "^23",
+    "rollup": "^0.62",
+    "rollup-plugin-typescript": "^0.8",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-auto-marshaller/rollup.config.js
+++ b/packages/dynamodb-auto-marshaller/rollup.config.js
@@ -1,0 +1,23 @@
+import typescript from 'rollup-plugin-typescript'
+
+export default {
+    input: './src/index.ts',
+    output: {
+        format: 'es',
+        file: './build/index.mjs'
+    },
+    plugins: [
+        typescript({
+            typescript: require('typescript'),
+            tsconfig: false,
+            module: "es2015",
+            moduleResolution: "node",
+            target: "es2017",
+            lib: [
+                "es2015"
+            ],
+            strict: true,
+            importHelpers: true
+        })
+    ]
+}

--- a/packages/dynamodb-batch-iterator/CHANGELOG.md
+++ b/packages/dynamodb-batch-iterator/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.7.0]
+Add a package rollup at `./build/index.mjs` to support tree shaking.
+
 ## [0.3.1]
 ### Fixed
  - When the source for a batch operation is a synchronous iterable, exhaust the

--- a/packages/dynamodb-batch-iterator/package.json
+++ b/packages/dynamodb-batch-iterator/package.json
@@ -16,10 +16,12 @@
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-batch-iterator/",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "module": "./build/index.mjs",
   "scripts": {
     "docs": "typedoc src",
-    "prepublishOnly": "tsc",
+    "prepublishOnly": "tsc && npm run rollup",
     "pretest": "tsc -p tsconfig.test.json",
+    "rollup": "rollup -c rollup.config.js",
     "test": "jest"
   },
   "author": {
@@ -32,6 +34,8 @@
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
     "jest": "^23",
+    "rollup": "^0.62",
+    "rollup-plugin-typescript": "^0.8",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-batch-iterator/rollup.config.js
+++ b/packages/dynamodb-batch-iterator/rollup.config.js
@@ -1,0 +1,23 @@
+import typescript from 'rollup-plugin-typescript'
+
+export default {
+    input: './src/index.ts',
+    output: {
+        format: 'es',
+        file: './build/index.mjs'
+    },
+    plugins: [
+        typescript({
+            typescript: require('typescript'),
+            tsconfig: false,
+            module: "es2015",
+            moduleResolution: "node",
+            target: "es2017",
+            lib: [
+                "es2015"
+            ],
+            strict: true,
+            importHelpers: true
+        })
+    ]
+}

--- a/packages/dynamodb-data-mapper-annotations/package.json
+++ b/packages/dynamodb-data-mapper-annotations/package.json
@@ -16,12 +16,14 @@
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-data-mapper-annotations/",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "module": "./build/index.mjs",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run rollup",
     "docs": "typedoc src",
     "integ": "npm run pretest && jest --config=jest.integration.js",
     "prepublishOnly": "npm run build",
     "pretest": "tsc -p tsconfig.test.json",
+    "rollup": "rollup -c rollup.config.js",
     "test": "jest"
   },
   "author": {
@@ -35,6 +37,8 @@
     "@types/uuid": "^3.0.0",
     "aws-sdk": "^2.7.0",
     "jest": "^23",
+    "rollup": "^0.62",
+    "rollup-plugin-typescript": "^0.8",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-data-mapper-annotations/rollup.config.js
+++ b/packages/dynamodb-data-mapper-annotations/rollup.config.js
@@ -1,0 +1,23 @@
+import typescript from 'rollup-plugin-typescript'
+
+export default {
+    input: './src/index.ts',
+    output: {
+        format: 'es',
+        file: './build/index.mjs'
+    },
+    plugins: [
+        typescript({
+            typescript: require('typescript'),
+            tsconfig: false,
+            module: "es2015",
+            moduleResolution: "node",
+            target: "es2017",
+            lib: [
+                "es2015"
+            ],
+            strict: true,
+            importHelpers: true
+        })
+    ]
+}

--- a/packages/dynamodb-data-mapper/CHANGELOG.md
+++ b/packages/dynamodb-data-mapper/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.7.0]
+Add a package rollup at `./build/index.mjs` to support tree shaking.
+
 ## [0.6.0]
 ### Fixed
  - Update `query` and `scan` to serialize whatever key properties are provided

--- a/packages/dynamodb-data-mapper/package.json
+++ b/packages/dynamodb-data-mapper/package.json
@@ -16,12 +16,14 @@
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-data-mapper/",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "module": "./build/index.mjs",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run rollup",
     "docs": "typedoc src",
     "integ": "npm run pretest && jest --config=jest.integration.js",
     "prepublishOnly": "npm run build",
     "pretest": "tsc -p tsconfig.test.json",
+    "rollup": "rollup -c rollup.config.js",
     "test": "jest"
   },
   "author": {
@@ -34,6 +36,8 @@
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
     "jest": "^23",
+    "rollup": "^0.62",
+    "rollup-plugin-typescript": "^0.8",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-data-mapper/rollup.config.js
+++ b/packages/dynamodb-data-mapper/rollup.config.js
@@ -1,0 +1,23 @@
+import typescript from 'rollup-plugin-typescript'
+
+export default {
+    input: './src/index.ts',
+    output: {
+        format: 'es',
+        file: './build/index.mjs'
+    },
+    plugins: [
+        typescript({
+            typescript: require('typescript'),
+            tsconfig: false,
+            module: "es2015",
+            moduleResolution: "node",
+            target: "es2017",
+            lib: [
+                "es2015"
+            ],
+            strict: true,
+            importHelpers: true
+        })
+    ]
+}

--- a/packages/dynamodb-data-marshaller/package.json
+++ b/packages/dynamodb-data-marshaller/package.json
@@ -16,10 +16,12 @@
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-data-marshaller/",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "module": "./build/index.mjs",
   "scripts": {
     "docs": "typedoc src",
-    "prepublishOnly": "tsc",
+    "prepublishOnly": "tsc && npm run rollup",
     "pretest": "tsc -p tsconfig.test.json",
+    "rollup": "rollup -c rollup.config.js",
     "test": "jest"
   },
   "author": {
@@ -32,6 +34,8 @@
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
     "jest": "^23",
+    "rollup": "^0.62",
+    "rollup-plugin-typescript": "^0.8",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-data-marshaller/rollup.config.js
+++ b/packages/dynamodb-data-marshaller/rollup.config.js
@@ -1,0 +1,23 @@
+import typescript from 'rollup-plugin-typescript'
+
+export default {
+    input: './src/index.ts',
+    output: {
+        format: 'es',
+        file: './build/index.mjs'
+    },
+    plugins: [
+        typescript({
+            typescript: require('typescript'),
+            tsconfig: false,
+            module: "es2015",
+            moduleResolution: "node",
+            target: "es2017",
+            lib: [
+                "es2015"
+            ],
+            strict: true,
+            importHelpers: true
+        })
+    ]
+}

--- a/packages/dynamodb-expressions/package.json
+++ b/packages/dynamodb-expressions/package.json
@@ -16,10 +16,12 @@
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-expressions/",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "module": "./build/index.mjs",
   "scripts": {
     "docs": "typedoc src",
-    "prepublishOnly": "tsc",
+    "prepublishOnly": "tsc && npm run rollup",
     "pretest": "tsc -p tsconfig.test.json",
+    "rollup": "rollup -c rollup.config.js",
     "test": "jest"
   },
   "author": {
@@ -32,6 +34,8 @@
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
     "jest": "^23",
+    "rollup": "^0.62",
+    "rollup-plugin-typescript": "^0.8",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-expressions/rollup.config.js
+++ b/packages/dynamodb-expressions/rollup.config.js
@@ -1,0 +1,23 @@
+import typescript from 'rollup-plugin-typescript'
+
+export default {
+    input: './src/index.ts',
+    output: {
+        format: 'es',
+        file: './build/index.mjs'
+    },
+    plugins: [
+        typescript({
+            typescript: require('typescript'),
+            tsconfig: false,
+            module: "es2015",
+            moduleResolution: "node",
+            target: "es2017",
+            lib: [
+                "es2015"
+            ],
+            strict: true,
+            importHelpers: true
+        })
+    ]
+}

--- a/packages/dynamodb-query-iterator/CHANGELOG.md
+++ b/packages/dynamodb-query-iterator/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.7.0]
+Add a package rollup at `./build/index.mjs` to support tree shaking.
+
 ## [0.6.0]
 Initial release

--- a/packages/dynamodb-query-iterator/package.json
+++ b/packages/dynamodb-query-iterator/package.json
@@ -16,10 +16,12 @@
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-scan-iterator/",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "module": "./build/index.mjs",
   "scripts": {
     "docs": "typedoc src",
-    "prepublishOnly": "tsc",
+    "prepublishOnly": "tsc && npm run rollup",
     "pretest": "tsc -p tsconfig.test.json",
+    "rollup": "rollup -c rollup.config.js",
     "test": "jest"
   },
   "author": {
@@ -32,6 +34,8 @@
     "@types/node": "^8.0.4",
     "aws-sdk": "^2.7.0",
     "jest": "^23",
+    "rollup": "^0.62",
+    "rollup-plugin-typescript": "^0.8",
     "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },

--- a/packages/dynamodb-query-iterator/rollup.config.js
+++ b/packages/dynamodb-query-iterator/rollup.config.js
@@ -1,0 +1,23 @@
+import typescript from 'rollup-plugin-typescript'
+
+export default {
+    input: './src/index.ts',
+    output: {
+        format: 'es',
+        file: './build/index.mjs'
+    },
+    plugins: [
+        typescript({
+            typescript: require('typescript'),
+            tsconfig: false,
+            module: "es2015",
+            moduleResolution: "node",
+            target: "es2017",
+            lib: [
+                "es2015"
+            ],
+            strict: true,
+            importHelpers: true
+        })
+    ]
+}


### PR DESCRIPTION
Adds a `./build/index.mjs` file in each package and adds a top-level `module` field to each `package.json` pointing thereto to support tree shaking and ES6 imports