### PR TITLE
Prune .js extension from main property in package.json files

### DIFF
--- a/packages/dynamodb-auto-marshaller/package.json
+++ b/packages/dynamodb-auto-marshaller/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/awslabs/dynamodb-data-mapper-js/issues"
   },
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-auto-marshaller/",
-  "main": "./build/index.js",
+  "main": "./build/index",
   "types": "./build/index.d.ts",
   "module": "./build/index.mjs",
   "scripts": {

--- a/packages/dynamodb-batch-iterator/package.json
+++ b/packages/dynamodb-batch-iterator/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/awslabs/dynamodb-data-mapper-js/issues"
   },
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-batch-iterator/",
-  "main": "./build/index.js",
+  "main": "./build/index",
   "types": "./build/index.d.ts",
   "module": "./build/index.mjs",
   "scripts": {

--- a/packages/dynamodb-data-mapper-annotations/package.json
+++ b/packages/dynamodb-data-mapper-annotations/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/awslabs/dynamodb-data-mapper-js/issues"
   },
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-data-mapper-annotations/",
-  "main": "./build/index.js",
+  "main": "./build/index",
   "types": "./build/index.d.ts",
   "module": "./build/index.mjs",
   "scripts": {

--- a/packages/dynamodb-data-mapper/package.json
+++ b/packages/dynamodb-data-mapper/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/awslabs/dynamodb-data-mapper-js/issues"
   },
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-data-mapper/",
-  "main": "./build/index.js",
+  "main": "./build/index",
   "types": "./build/index.d.ts",
   "module": "./build/index.mjs",
   "scripts": {

--- a/packages/dynamodb-data-marshaller/package.json
+++ b/packages/dynamodb-data-marshaller/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/awslabs/dynamodb-data-mapper-js/issues"
   },
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-data-marshaller/",
-  "main": "./build/index.js",
+  "main": "./build/index",
   "types": "./build/index.d.ts",
   "module": "./build/index.mjs",
   "scripts": {

--- a/packages/dynamodb-expressions/package.json
+++ b/packages/dynamodb-expressions/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/awslabs/dynamodb-data-mapper-js/issues"
   },
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-expressions/",
-  "main": "./build/index.js",
+  "main": "./build/index",
   "types": "./build/index.d.ts",
   "module": "./build/index.mjs",
   "scripts": {

--- a/packages/dynamodb-query-iterator/package.json
+++ b/packages/dynamodb-query-iterator/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/awslabs/dynamodb-data-mapper-js/issues"
   },
   "homepage": "https://awslabs.github.io/dynamodb-data-mapper-js/packages/dynamodb-scan-iterator/",
-  "main": "./build/index.js",
+  "main": "./build/index",
   "types": "./build/index.d.ts",
   "module": "./build/index.mjs",
   "scripts": {


### PR DESCRIPTION
Should resolve #82; currently doing some local testing with `webpack` and `serverless` to make sure this resolves the packaging issue.