### PR TITLE
Feature/function expression predicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "jest": {
+    "testEnvironment": "node"
+  }
 }

--- a/packages/dynamodb-data-marshaller/src/marshallExpression.spec.ts
+++ b/packages/dynamodb-data-marshaller/src/marshallExpression.spec.ts
@@ -128,7 +128,40 @@ describe('marshallConditionExpression', () => {
                 '#attr2': 'nested_scalar',
             },
             ExpressionAttributeValues: {},
-        })
+        });
+
+        expect(marshallConditionExpression(
+            {type: 'Function', name: 'attribute_exists', subject: 'nested.nested.scalar'},
+            schema
+        )).toEqual({
+            expression: 'attribute_exists(#attr0.#attr1.#attr2)',
+            ExpressionAttributeNames: {
+                '#attr0': 'nested_level_1',
+                '#attr1': 'nested_level_2',
+                '#attr2': 'nested_scalar',
+            },
+            ExpressionAttributeValues: {},
+        });
+
+        expect(marshallConditionExpression(
+            {
+                type: 'Function',
+                name: 'contains',
+                subject: 'nested.nested.scalar',
+                expected: 'substr'
+            },
+            schema
+        )).toEqual({
+            expression: 'contains(#attr0.#attr1.#attr2, :val3)',
+            ExpressionAttributeNames: {
+                '#attr0': 'nested_level_1',
+                '#attr1': 'nested_level_2',
+                '#attr2': 'nested_scalar',
+            },
+            ExpressionAttributeValues: {
+                ':val3': {S: 'substr'}
+            },
+        });
     });
 });
 

--- a/packages/dynamodb-data-marshaller/src/marshallExpression.ts
+++ b/packages/dynamodb-data-marshaller/src/marshallExpression.ts
@@ -184,6 +184,23 @@ function normalizeConditionExpression(
                 object: normalizeIfPath(expression.object, schema),
             };
 
+        case 'Function':
+            switch (expression.name) {
+                case 'attribute_exists':
+                case 'attribute_not_exists':
+                    return {
+                        ...expression,
+                        subject: toSchemaName(expression.subject, schema)
+                    };
+                case 'attribute_type':
+                case 'begins_with':
+                case 'contains':
+                    return {
+                        ...expression,
+                        subject: toSchemaName(expression.subject, schema)
+                    };
+            }
+
         case 'Between':
             return {
                 ...expression,


### PR DESCRIPTION
Provides factory functions for condition expression predicates that must be serialized as function expressions, such as `attribute_exists` or `begins_with`. These may be used in a query or scan condition:

```typescript
mapper.scan(MappedClass, {
    condition: {
        foo: attributeExists(),
        bar: attributeNotExists(),
        baz: beginsWith('quux')
     }
});
```

Resolves #57