### PR TITLE
Add support for nested function expressions

### DIFF
--- a/packages/dynamodb-expressions/src/FunctionExpression.spec.ts
+++ b/packages/dynamodb-expressions/src/FunctionExpression.spec.ts
@@ -52,5 +52,27 @@ describe('FunctionExpression', () => {
                 ':val1': {S: 'baz'},
             });
         });
+
+        it('should support nested function expressions', () => {
+            const nestedFunction = new FunctionExpression(
+                'foo',
+                new AttributePath('bar'),
+                'baz',
+                new FunctionExpression('fizz', new FunctionExpression('buzz', new AttributePath('bar')))
+            )
+            const attributes = new ExpressionAttributes();
+
+            expect(
+                nestedFunction.serialize(attributes)
+            ).toBe('foo(#attr0, :val1, fizz(buzz(#attr0)))');
+
+            expect(attributes.names).toEqual({
+                '#attr0': 'bar',
+            });
+
+            expect(attributes.values).toEqual({
+                ':val1': {S: 'baz'},
+            });
+        });
     });
 });

--- a/packages/dynamodb-expressions/src/FunctionExpression.ts
+++ b/packages/dynamodb-expressions/src/FunctionExpression.ts
@@ -20,11 +20,16 @@ export class FunctionExpression implements AttributeBearingExpression {
     }
 
     serialize(attributes: ExpressionAttributes) {
-        const expressionSafeArgs = this.args.map(
-            arg => AttributePath.isAttributePath(arg)
-                ? attributes.addName(arg)
-                : attributes.addValue(arg)
-        );
+        const expressionSafeArgs: Array<string> = this.args.map(arg => {
+            if (AttributePath.isAttributePath(arg)) {
+                return attributes.addName(arg);
+            } else if (FunctionExpression.isFunctionExpression(arg)) {
+                return arg.serialize(attributes);
+            }
+
+            return attributes.addValue(arg);
+        });
+
         return `${this.name}(${expressionSafeArgs.join(', ')})`;
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/dynamodb-data-mapper-js/issues/150

*Description of changes:*
Updates function expression serialization to support nested functions.

/cc @AllanFly120 && @trivikr 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
