### PR TITLE
Fix issue when using batch operations on different classes with the same table name

### DIFF
--- a/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
@@ -437,9 +437,10 @@ describe('DataMapper', () => {
                     },
                 ];
 
+                let currentRequest = 0;
                 for (let i = 0; i < 325; i++) {
                     gets.push(new Item(i));
-                    expected[Math.floor(i / 100)][0].RequestItems.foo.Keys
+                    expected[currentRequest][0].RequestItems.foo.Keys
                         .push({fizz: {N: String(i)}});
 
                     const response = {
@@ -447,13 +448,17 @@ describe('DataMapper', () => {
                         buzz: {BOOL: i % 2 === 0},
                         pop: {S: 'Goes the weasel'}
                     };
+
                     if (failures.has(String(i))) {
-                        responses[Math.floor(i / 100)].UnprocessedKeys.foo.Keys
+                        responses[currentRequest].UnprocessedKeys.foo.Keys
                             .push({fizz: {N: String(i)}});
-                        responses[3].Responses.foo.push(response);
-                    } else {
-                        responses[Math.floor(i / 100)].Responses.foo
-                            .push(response);
+                        responses[currentRequest + 1].Responses.foo.push(response);
+                    }
+                    else {
+                        responses[currentRequest].Responses.foo.push(response);
+                        if (responses[currentRequest].Responses.foo.length === 99) {
+                            currentRequest++;
+                        }
                     }
                 }
 

--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -1128,7 +1128,6 @@ export class DataMapper {
         convertedOptions: PerTableOptions
     ): Promise<Array<[string, AttributeMap]>> {
         let keys: Array<[string, AttributeMap]> = [];
-
         for await (const item of items) {
             const unprefixed = getTableName(item);
             const tableName = this.tableNamePrefix + unprefixed;
@@ -1157,7 +1156,6 @@ export class DataMapper {
 
             keys.push([tableName, marshalled]);
         }
-
         return keys;
     }
 
@@ -1166,7 +1164,6 @@ export class DataMapper {
         state: BatchState<T>
     ): Promise<Array<[string, WriteRequest]>> {
         let keys: Array<[string, WriteRequest]> = [];
-
         for await (const [type, item] of items) {
             const unprefixed = getTableName(item);
             const tableName = this.tableNamePrefix + unprefixed;

--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -1127,7 +1127,7 @@ export class DataMapper {
         options: {[tableName: string]: BatchGetTableOptions},
         convertedOptions: PerTableOptions
     ): Promise<Array<[string, AttributeMap]>> {
-        let keys: Array<[string, AttributeMap]> = [];
+        let marshalledItems: Array<[string, AttributeMap]> = [];
         for await (const item of items) {
             const unprefixed = getTableName(item);
             const tableName = this.tableNamePrefix + unprefixed;
@@ -1154,16 +1154,16 @@ export class DataMapper {
                 schema,
             };
 
-            keys.push([tableName, marshalled]);
+            marshalledItems.push([tableName, marshalled]);
         }
-        return keys;
+        return marshalledItems;
     }
 
     private async mapWriteBatch<T extends StringToAnyObjectMap>(
         items: SyncOrAsyncIterable<[WriteType, T]>,
         state: BatchState<T>
     ): Promise<Array<[string, WriteRequest]>> {
-        let keys: Array<[string, WriteRequest]> = [];
+        let marshalledItems: Array<[string, WriteRequest]> = [];
         for await (const [type, item] of items) {
             const unprefixed = getTableName(item);
             const tableName = this.tableNamePrefix + unprefixed;
@@ -1188,9 +1188,9 @@ export class DataMapper {
                 schema,
             };
 
-            keys.push([tableName, marshalled]);
+            marshalledItems.push([tableName, marshalled]);
         }
-        return keys;
+        return marshalledItems;
     }
 }
 

--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -1339,7 +1339,7 @@ function itemIdentifier(
     const keyAttributes: Array<string> = [];
     for (const key of keyProperties) {
         const value = marshalled[key];
-        `${key}=${value.B || value.N || value.S}`;
+        keyAttributes.push(`${key}=${value.B || value.N || value.S}`);
     }
 
     return keyAttributes.join(':');


### PR DESCRIPTION
Resolves #47 

*Description of changes:*
In DataMapper.ts itemIdentifier function always returned ":" as no items were pushed to the keyAttributes array.
This caused problems with batch operations of different models using the same table name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
