### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ instance of `DataMapper`:
 
 ```typescript
 import {DataMapper} from '@aws/dynamodb-data-mapper';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const mapper = new DataMapper({
     client: new DynamoDB({region: 'us-west-2'}), // the SDK client used to execute operations

--- a/packages/dynamodb-batch-iterator/README.md
+++ b/packages/dynamodb-batch-iterator/README.md
@@ -21,7 +21,7 @@ object stream wrapped with [async-iter-stream](https://github.com/calvinmetcalf/
 
 ```typescript
 import { BatchGet } from '@aws/dynamodb-batch-iterator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const dynamoDb = new DynamoDB({region: 'us-west-2'});
 const keys = [
@@ -60,7 +60,7 @@ key as described [in the Amazon DynamoDB API reference](http://docs.aws.amazon.c
 
 ```typescript
 import { BatchWrite } from '@aws/dynamodb-batch-iterator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const dynamoDb = new DynamoDB({region: 'us-west-2'});
 const keys = [

--- a/packages/dynamodb-batch-iterator/src/BatchGet.ts
+++ b/packages/dynamodb-batch-iterator/src/BatchGet.ts
@@ -2,7 +2,7 @@ import { BatchGetOptions, PerTableOptions } from './BatchGetOptions';
 import { BatchOperation } from './BatchOperation';
 import { SyncOrAsyncIterable, TableState } from './types';
 import { AttributeMap, BatchGetItemInput } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 export const MAX_READ_BATCH_SIZE = 100;
 

--- a/packages/dynamodb-batch-iterator/src/BatchOperation.ts
+++ b/packages/dynamodb-batch-iterator/src/BatchOperation.ts
@@ -5,7 +5,7 @@ import {
     TableStateElement,
     ThrottledTableConfiguration,
 } from './types';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 if (Symbol && !Symbol.asyncIterator) {
     (Symbol as any).asyncIterator = Symbol.for("__@@asyncIterator__");

--- a/packages/dynamodb-data-mapper/README.md
+++ b/packages/dynamodb-data-mapper/README.md
@@ -75,7 +75,7 @@ import {
     DynamoDbSchema,
     DynamoDbTable,
 } from '@aws/dynamodb-data-mapper';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const client = new DynamoDB({region: 'us-west-2'});
 const mapper = new DataMapper({client});

--- a/packages/dynamodb-data-mapper/src/DataMapper.integ.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.integ.ts
@@ -3,7 +3,7 @@ import {ItemNotFoundException} from './ItemNotFoundException';
 import {DynamoDbSchema, DynamoDbTable} from './protocols';
 import {hostname} from 'os';
 import {hrtime} from 'process';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 import {DocumentType} from "@aws/dynamodb-data-marshaller";
 import {Schema} from "@aws/dynamodb-data-marshaller";
 import {equals} from "@aws/dynamodb-expressions";

--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -87,7 +87,7 @@ import {
     PutItemInput,
     UpdateItemInput,
 } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 require('./asyncIteratorSymbolPolyfill');
 

--- a/packages/dynamodb-data-mapper/src/ParallelScanIterator.ts
+++ b/packages/dynamodb-data-mapper/src/ParallelScanIterator.ts
@@ -2,7 +2,7 @@ import { Iterator } from './Iterator';
 import { ParallelScanOptions } from './namedParameters';
 import { ParallelScanPaginator } from './ParallelScanPaginator';
 import { ZeroArgumentsConstructor } from '@aws/dynamodb-data-marshaller';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 /**
  * Iterates over each item returned by a parallel DynamoDB scan until no more

--- a/packages/dynamodb-data-mapper/src/ParallelScanPaginator.ts
+++ b/packages/dynamodb-data-mapper/src/ParallelScanPaginator.ts
@@ -18,7 +18,7 @@ import {
     unmarshallItem,
     ZeroArgumentsConstructor,
 } from '@aws/dynamodb-data-marshaller';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 /**
  * Iterates over each page of items returned by a parallel DynamoDB scan until

--- a/packages/dynamodb-data-mapper/src/QueryIterator.ts
+++ b/packages/dynamodb-data-mapper/src/QueryIterator.ts
@@ -6,7 +6,7 @@ import {
     ConditionExpression,
     ConditionExpressionPredicate,
 } from '@aws/dynamodb-expressions';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 /**
  * Iterates over each item returned by a DynamoDB query until no more pages are

--- a/packages/dynamodb-data-mapper/src/QueryPaginator.ts
+++ b/packages/dynamodb-data-mapper/src/QueryPaginator.ts
@@ -16,7 +16,7 @@ import {
     isConditionExpressionPredicate,
 } from '@aws/dynamodb-expressions';
 import { QueryInput } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 /**
  * Iterates over each page of items returned by a DynamoDB query until no more

--- a/packages/dynamodb-data-mapper/src/ScanIterator.ts
+++ b/packages/dynamodb-data-mapper/src/ScanIterator.ts
@@ -2,7 +2,7 @@ import { Iterator } from './Iterator';
 import { SequentialScanOptions } from './namedParameters';
 import { ScanPaginator } from './ScanPaginator';
 import { ZeroArgumentsConstructor } from '@aws/dynamodb-data-marshaller';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 /**
  * Iterates over each item returned by a DynamoDB scan until no more pages are

--- a/packages/dynamodb-data-mapper/src/ScanPaginator.ts
+++ b/packages/dynamodb-data-mapper/src/ScanPaginator.ts
@@ -3,7 +3,7 @@ import { SequentialScanOptions } from './namedParameters';
 import { Paginator } from './Paginator';
 import { ScanPaginator as BasePaginator } from '@aws/dynamodb-query-iterator';
 import { ZeroArgumentsConstructor } from '@aws/dynamodb-data-marshaller';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 /**
  * Iterates over each page of items returned by a DynamoDB scan until no more

--- a/packages/dynamodb-data-mapper/src/namedParameters/DataMapperConfiguration.ts
+++ b/packages/dynamodb-data-mapper/src/namedParameters/DataMapperConfiguration.ts
@@ -1,4 +1,4 @@
-import DynamoDB = require("aws-sdk/clients/dynamodb");
+const DynamoDB = require("aws-sdk/clients/dynamodb");
 import { ReadConsistency } from '../constants';
 
 export interface DataMapperConfiguration {

--- a/packages/dynamodb-query-iterator/README.md
+++ b/packages/dynamodb-query-iterator/README.md
@@ -23,7 +23,7 @@ Retrieves all pages of a DynamoDB `query` in order.
 
 ```typescript
 import { QueryPaginator } from '@aws/dynamodb-query-iterator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const paginator = new QueryPaginator(
     new DynamoDB({region: 'us-west-2'}),
@@ -62,7 +62,7 @@ as the `ExclusiveStartKey` for another `QueryPaginator` instance:
 ```typescript
 import { QueryPaginator } from '@aws/dynamodb-query-iterator';
 import { QueryInput } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const dynamoDb = new DynamoDB({region: 'us-west-2'});
 const input: QueryInput = {
@@ -99,7 +99,7 @@ Retrieves all pages of a DynamoDB `scan` in order.
 
 ```typescript
 import { ScanPaginator } from '@aws/dynamodb-query-iterator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const paginator = new ScanPaginator(
     new DynamoDB({region: 'us-west-2'}),
@@ -134,7 +134,7 @@ as the `ExclusiveStartKey` for another `ScanPaginator` instance:
 ```typescript
 import { ScanPaginator } from '@aws/dynamodb-query-iterator';
 import { ScanInput } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const dynamoDb = new DynamoDB({region: 'us-west-2'});
 const input: ScanInput = {
@@ -171,7 +171,7 @@ provided.
 
 ```typescript
 import { ParallelScanPaginator } from '@aws/dynamodb-query-iterator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const paginator = new ParallelScanPaginator(
     new DynamoDB({region: 'us-west-2'}),
@@ -209,7 +209,7 @@ import {
     ParallelScanInput,
     ParallelScanPaginator,
 } from '@aws/dynamodb-query-iterator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const client = new DynamoDB({region: 'us-west-2'});
 const input: ParallelScanInput = {
@@ -251,7 +251,7 @@ Retrieves all records of a DynamoDB `query` in order.
 
 ```typescript
 import { QueryIterator } from '@aws/dynamodb-query-iterator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const iterator = new QueryIterator(
     new DynamoDB({region: 'us-west-2'}),
@@ -289,7 +289,7 @@ Retrieves all records of a DynamoDB `scan` in order.
 
 ```typescript
 import { ScanIterator } from '@aws/dynamodb-query-iterator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const iterator = new ScanIterator(
     new DynamoDB({region: 'us-west-2'}),
@@ -327,7 +327,7 @@ provided.
 
 ```typescript
 import { ParallelScanIterator} from '@aws/dynamodb-query-iterator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 const iterator = new ParallelScanIterator(
     new DynamoDB({region: 'us-west-2'}),

--- a/packages/dynamodb-query-iterator/src/ParallelScanIterator.ts
+++ b/packages/dynamodb-query-iterator/src/ParallelScanIterator.ts
@@ -4,7 +4,7 @@ import {
     ParallelScanPaginator,
     ParallelScanState,
 } from './ParallelScanPaginator';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 export class ParallelScanIterator extends ItemIterator<ParallelScanPaginator> {
     constructor(

--- a/packages/dynamodb-query-iterator/src/ParallelScanPaginator.ts
+++ b/packages/dynamodb-query-iterator/src/ParallelScanPaginator.ts
@@ -4,7 +4,7 @@ import { mergeConsumedCapacities } from './mergeConsumedCapacities';
 import { ParallelScanInput } from './ParallelScanInput';
 import { ScanPaginator } from './ScanPaginator';
 import { ConsumedCapacity, Key } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 /**
  * Pagination state for a scan segment for which the first page has not yet been

--- a/packages/dynamodb-query-iterator/src/QueryIterator.ts
+++ b/packages/dynamodb-query-iterator/src/QueryIterator.ts
@@ -1,7 +1,7 @@
 import { ItemIterator } from './ItemIterator';
 import { QueryPaginator } from './QueryPaginator';
 import { QueryInput } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 export class QueryIterator extends ItemIterator<QueryPaginator> {
     constructor(client: DynamoDB, input: QueryInput, limit?: number) {

--- a/packages/dynamodb-query-iterator/src/QueryPaginator.ts
+++ b/packages/dynamodb-query-iterator/src/QueryPaginator.ts
@@ -1,7 +1,7 @@
 import { DynamoDbPaginator } from './DynamoDbPaginator';
 import { DynamoDbResultsPage } from './DynamoDbResultsPage';
 import { QueryInput } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 export class QueryPaginator extends DynamoDbPaginator {
     private nextRequest?: QueryInput;

--- a/packages/dynamodb-query-iterator/src/ScanIterator.ts
+++ b/packages/dynamodb-query-iterator/src/ScanIterator.ts
@@ -1,7 +1,7 @@
 import { ItemIterator } from './ItemIterator';
 import { ScanPaginator } from './ScanPaginator';
 import { ScanInput } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 export class ScanIterator extends ItemIterator<ScanPaginator> {
     constructor(client: DynamoDB, input: ScanInput, limit?: number) {

--- a/packages/dynamodb-query-iterator/src/ScanPaginator.ts
+++ b/packages/dynamodb-query-iterator/src/ScanPaginator.ts
@@ -1,7 +1,7 @@
 import { DynamoDbPaginator } from './DynamoDbPaginator';
 import { DynamoDbResultsPage } from './DynamoDbResultsPage';
 import { ScanInput } from 'aws-sdk/clients/dynamodb';
-import DynamoDB = require('aws-sdk/clients/dynamodb');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
 
 export class ScanPaginator extends DynamoDbPaginator {
     private nextRequest?: ScanInput;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It was original
`import DynamoDB = require('aws-sdk/clients/dynamodb');`
Personally think it's a typo.

Feel free to reject if it's not. :)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
