### PR TITLE
Add tests to ensure ItemNotFoundException inherits from Error

### DIFF
--- a/packages/dynamodb-batch-iterator/src/BatchOperation.ts
+++ b/packages/dynamodb-batch-iterator/src/BatchOperation.ts
@@ -211,7 +211,7 @@ export abstract class BatchOperation<
                 ]);
 
             if (isIteratorResult(toProcess)) {
-                this.sourceDone = toProcess.done;
+                this.sourceDone = Boolean(toProcess.done);
                 if (!this.sourceDone) {
                     this.addToSendQueue(toProcess.value);
                     this.sourceNext = this.iterator.next();

--- a/packages/dynamodb-data-mapper/src/ItemNotFoundException.spec.ts
+++ b/packages/dynamodb-data-mapper/src/ItemNotFoundException.spec.ts
@@ -20,6 +20,16 @@ describe('ItemNotFoundException', () => {
         expect(exception.name).toBe('ItemNotFoundException');
     });
 
+    it('should be an instance of ItemNotFoundException', () => {
+        const exception = new ItemNotFoundException({} as any, 'message');
+        expect(exception).toBeInstanceOf(ItemNotFoundException);
+    });
+
+    it('should be an instance of Error', () => {
+        const exception = new ItemNotFoundException({} as any, 'message');
+        expect(exception).toBeInstanceOf(Error);
+    });
+
     it(
         'should construct a default message from the item sought if no message supplied',
         () => {

--- a/packages/dynamodb-data-mapper/src/ItemNotFoundException.ts
+++ b/packages/dynamodb-data-mapper/src/ItemNotFoundException.ts
@@ -8,11 +8,15 @@ import {GetItemInput} from "aws-sdk/clients/dynamodb";
 export class ItemNotFoundException extends Error {
     readonly name = 'ItemNotFoundException';
 
+    __proto__: Error;
     constructor(
         public readonly itemSought: GetItemInput,
         message: string = defaultErrorMessage(itemSought)
     ) {
         super(message);
+
+        // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+        this.__proto__ = ItemNotFoundException.prototype;
     }
 }
 

--- a/packages/dynamodb-data-mapper/src/ItemNotFoundException.ts
+++ b/packages/dynamodb-data-mapper/src/ItemNotFoundException.ts
@@ -1,4 +1,10 @@
-import {GetItemInput} from "aws-sdk/clients/dynamodb";
+import { GetItemInput } from "aws-sdk/clients/dynamodb";
+const {
+    setPrototypeOf = function (obj: any, proto: any) {
+        obj.__proto__ = proto;
+        return obj;
+    },
+} = Object;
 
 /**
  * An exception thrown when an item was sought with a DynamoDB::GetItem
@@ -8,7 +14,6 @@ import {GetItemInput} from "aws-sdk/clients/dynamodb";
 export class ItemNotFoundException extends Error {
     readonly name = 'ItemNotFoundException';
 
-    __proto__: Error;
     constructor(
         public readonly itemSought: GetItemInput,
         message: string = defaultErrorMessage(itemSought)
@@ -16,12 +21,12 @@ export class ItemNotFoundException extends Error {
         super(message);
 
         // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
-        this.__proto__ = ItemNotFoundException.prototype;
+        setPrototypeOf(this, ItemNotFoundException.prototype);
     }
 }
 
 function defaultErrorMessage(itemSought: GetItemInput): string {
     return `No item with the key ${
         JSON.stringify(itemSought.Key)
-    } found in the ${itemSought.TableName} table.`;
+        } found in the ${itemSought.TableName} table.`;
 }

--- a/packages/dynamodb-data-mapper/src/Paginator.ts
+++ b/packages/dynamodb-data-mapper/src/Paginator.ts
@@ -90,8 +90,10 @@ export abstract class Paginator<T> implements AsyncIterableIterator<Array<T>> {
                     this.valueConstructor
                 );
 
+                const items: any[] = value.Items || [];
+
                 return {
-                    value: (value.Items || []).map(item => unmarshallItem(
+                    value: (items).map(item => unmarshallItem(
                         this.itemSchema,
                         item,
                         this.valueConstructor


### PR DESCRIPTION
Currently if an item does not exist in the dynamodb table an error is thrown but the error that is thrown is not inheriting from the error class they are constructed from. It turns out this is a bug/intential-change in TypeScript.
TypeScript have a page on their Wiki which explains how to extend from Error correctly -- https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work

```js
import {
    DataMapper,
    DynamoDbSchema,
    DynamoDbTable,
} from '@aws/dynamodb-data-mapper';
import DynamoDB = require('aws-sdk/clients/dynamodb');

const client = new DynamoDB({
    region: 'us-west-2'
});
const mapper = new DataMapper({
    client
});

class MyDomainModel {
    id: string;
}

Object.defineProperties(MyDomainModel.prototype, {
    [DynamoDbTable]: {
        value: 'MyTable'
    },
    [DynamoDbSchema]: {
        value: {
            id: {
                type: 'String',
                keyType: 'HASH'
            },
        },
    },
});

async function main() {
    // delete an object
    const toDelete = new MyDomainModel();
    toDelete.id = 'DELETE_ME';
    // this throws as it's fetching an object that does not exist,
    // the error should be an instance of ItemNotFoundException
    await mapper.get(toDelete)
        .catch(err => console.log(err instanceof ItemNotFoundException)); // <---- This should be true but currently is false
}

main();
```