### PR TITLE
add custom expression on update operation

### DIFF
--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -956,6 +956,7 @@ export class DataMapper {
         }
         let {
             condition,
+            customExpression,
             onMissing = 'remove',
             skipVersionCheck = this.skipVersionCheck,
         } = options;
@@ -986,6 +987,8 @@ export class DataMapper {
                 if (onMissing === 'remove') {
                     expr.remove(key);
                 }
+            } else if (customExpression) {
+                expr.set(key, customExpression)
             } else {
                 const marshalled = marshallValue(fieldSchema, inputMember);
                 if (marshalled) {

--- a/packages/dynamodb-data-mapper/src/namedParameters/UpdateOptions.ts
+++ b/packages/dynamodb-data-mapper/src/namedParameters/UpdateOptions.ts
@@ -8,6 +8,12 @@ export interface UpdateOptions {
      */
     condition?: ConditionExpression;
 
+
+    /**
+     * A customExpression overwrite Value attribute of UpdateExpression if specfied
+     */
+    customExpression?: AttributeValue | FunctionExpression | MathematicalExpression | any;
+
     /**
      * Whether the absence of a value defined in the schema should be treated as
      * a directive to remove the property from the item.


### PR DESCRIPTION
*Issue #, if available:*
#174 

*Description of changes:*
It can be specified customExpression on update operation.
customExpression will be used when this parameter specified in UpdateOption parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
