### PR TITLE
Typo fix in the example code

### DIFF
--- a/packages/dynamodb-auto-marshaller/README.md
+++ b/packages/dynamodb-auto-marshaller/README.md
@@ -56,7 +56,7 @@ const marshalled = marshaller.marshallItem(original);
 
 // the output of `.marshallItem` can be converted back to a JavaScript type with
 // `.unmarshallItem`
-const unmarshalled = marshaller.unmarshallItem(original);
+const unmarshalled = marshaller.unmarshallItem(marshalled);
 
 // With a few caveats (listed below), the unmarshalled value should have the
 // same structure and data as the original value.


### PR DESCRIPTION
`unmarshallItem` needs a marshalled object to unmarshal.

*Issue #, if available:*

*Description of changes:*
Just a small typo fix. Incorrect variable passed down to unmarshallItem function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
