### PR TITLE
Add new DataMapper class method, generateUpdateExpression

### DIFF
--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -954,6 +954,38 @@ export class DataMapper {
         } else {
             item = itemOrParameters as T;
         }
+
+        const [expression, key, condition] = this.generateUpdateExpression(
+            item,
+            options
+        );
+
+        return this.doExecuteUpdateExpression(
+            expression,
+            key,
+            getSchema(item),
+            getTableName(item),
+            item.constructor as ZeroArgumentsConstructor<T>,
+            { condition }
+        );
+    }
+
+    /**
+     * Generate an update expression for an UpdateItem operation using the schema accessible via the
+     * {DynamoDbSchema} method and the table name accessible via the
+     * {DynamoDbTable} method on the item supplied.
+     *
+     * @param item      The item to save to DynamoDB
+     * @param options   Options to configure the UpdateItem operation
+     */
+    generateUpdateExpression<T extends StringToAnyObjectMap = StringToAnyObjectMap>(
+        item: T,
+        options: UpdateOptions = {}
+    ): [ 
+        UpdateExpression,
+        {[propertyName: string]: any},
+        ConditionExpression?
+    ] {
         let {
             condition,
             onMissing = 'remove',
@@ -994,14 +1026,7 @@ export class DataMapper {
             }
         }
 
-        return this.doExecuteUpdateExpression(
-            expr,
-            itemKey,
-            getSchema(item),
-            getTableName(item),
-            item.constructor  as ZeroArgumentsConstructor<T>,
-            {condition}
-        );
+        return [expr, itemKey, condition];
     }
 
     /**

--- a/packages/dynamodb-data-mapper/src/Paginator.ts
+++ b/packages/dynamodb-data-mapper/src/Paginator.ts
@@ -91,7 +91,7 @@ export abstract class Paginator<T> implements AsyncIterableIterator<Array<T>> {
                 );
 
                 return {
-                    value: (value.Items || []).map(item => unmarshallItem(
+                    value: (value.Items || []).map((item: typeof value.Items) => unmarshallItem(
                         this.itemSchema,
                         item,
                         this.valueConstructor


### PR DESCRIPTION
*Description of changes:*
Add new `DataMapper` class method, `generateUpdateExpression`, which gives the ability to extend the update expression generated by existing `update` method.

*Reasoning:*
I have found myself in a situation where I want to extend the update expression generated by `mapper.update`, however I don't believe there is an existing way to do this? Specifically I wanted to add some additional REMOVE clauses to the update expression based on some custom logic. Introducing the `generateUpdateExpression` method allows developers to extend the functionality of the built in `mapper.update` method without having to generate their own update expression from scratch. 

Here is some sample code showing how I am using the new `generateUpdateExpression` method: 
```js
// Newly added method below
const [updateExpression, key, condition] = mapper.generateUpdateExpression(
  Object.assign(new Account(), updates),
  {
    condition: generateUserIdCondition(userId),
    onMissing: "skip",
  }
);

// Ability to extend generated update expression with custom logic before execution
attributesToRemove.forEach((a) => updateExpression.remove(a));

return mapper.executeUpdateExpression(updateExpression, key, Account, {
  condition,
});

```

Not really too fussed if this doesn't end up in the library, however it helped me in one of my projects so I thought I should PR in case it is a feature that might help others too. For this reason I have **not included any unit tests** with this PR as I didn't want to invest a heap of time into this change in case it doesn't make it into the lib. 

Open to any feedback! :) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
