### PR TITLE
Add returnValues option to executeUpdateExpression

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   ],
   "jest": {
     "testEnvironment": "node",
-    "testPathIgnorePatterns": ["/node_modules/", ".ts"]
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      ".ts"
+    ]
   }
 }

--- a/packages/dynamodb-data-mapper/README.md
+++ b/packages/dynamodb-data-mapper/README.md
@@ -703,3 +703,6 @@ Takes four parameters:
         order for the update operation to be executed. Please refer to the
         documentation for the `@aws/dynamodb-expressions` package for guidance
         on creating condition expression objects.
+
+    * `returnValues` - One of the values: `ALL_NEW` | `ALL_OLD` | `UPDATED_NEW`
+        | `UPDATED_OLD` | `NONE`

--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -1041,7 +1041,7 @@ export class DataMapper {
      * @param options           Options with which to customize the UpdateItem
      *                          request.
      *
-     * @returns The updated item.
+     * @returns The updated item in accordance to returnValue.
      */
     async executeUpdateExpression<
         T extends StringToAnyObjectMap = StringToAnyObjectMap
@@ -1073,7 +1073,7 @@ export class DataMapper {
     ): Promise<T> {
         const req: UpdateItemInput = {
             TableName: this.tableNamePrefix + tableName,
-            ReturnValues: 'ALL_NEW',
+            ReturnValues: options.returnValues || 'ALL_NEW',
             Key: marshallKey(schema, key),
         };
 

--- a/packages/dynamodb-data-mapper/src/namedParameters/ExecuteUpdateExpressionOptions.ts
+++ b/packages/dynamodb-data-mapper/src/namedParameters/ExecuteUpdateExpressionOptions.ts
@@ -6,4 +6,5 @@ export interface ExecuteUpdateExpressionOptions {
      * predicated.
      */
     condition?: ConditionExpression;
+    returnValues?: 'ALL_NEW' | 'ALL_OLD' | 'UPDATED_NEW' | 'UPDATED_ALL' | 'NONE';
 }


### PR DESCRIPTION
*Description of changes:*

Adds the ability to specify the return value option of an `update-item` expression