### PR TITLE
annotations: Add example of usage with Glboal Secondary Indexes

### DIFF
--- a/packages/dynamodb-data-mapper-annotations/README.md
+++ b/packages/dynamodb-data-mapper-annotations/README.md
@@ -98,6 +98,37 @@ class BlogPost {
 }
 ```
 
+To declare Global Secondary Index (GSI) you should use the `indexKeyConfigurations` property of the `attribute` annotation:
+
+```typescript
+import {
+    attribute, 
+    hashKey,
+    table,
+} from '@aws/dynamodb-data-mapper-annotations';
+
+@table('posts')
+class BlogPost {
+    @hashKey()
+    id: string;
+
+    // define a GSI index named `authorIndex` that uses `author`` as partition key
+    @attribute({indexKeyConfigurations: {
+        authorIndex: 'HASH'
+    }})
+    author?: string;
+
+    // define a GSI index named `postedAtIndex` that uses `postedAt`` as sort key
+    @attribute({indexKeyConfigurations: {
+        postedAtIndex: 'RANGE'
+    }})
+    postedAt?: Date;
+
+    @attribute()
+    text?: string;
+}
+```
+
 ## Supported Annotations
 
 ### `attribute`


### PR DESCRIPTION
*Issue #, if available:*
Right now there is very limited information on how to annotate properly the GSI related columns. In one of our projects previous devs did use the @hashKey annotation for columns that were part just of a GSI partition key, which is wrong and was causing problems that we spent quite some time to understand why it was happening.

*Description of changes:*
This is adding one code example with two types of GSI indexes (hash and ranged) to the annotations README file. While it's not a full documentation, I feel it will be useful to have these basic examples that can guide the developers and save a lot of time in investigation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
